### PR TITLE
TRACING-3360 | Distributed tracing 2.9 release notes

### DIFF
--- a/modules/distr-tracing-rn-known-issues.adoc
+++ b/modules/distr-tracing-rn-known-issues.adoc
@@ -44,8 +44,6 @@ These are the known issues for {DTProductName}:
 
 
 
-* link:https://issues.redhat.com/browse/OBSDA-220[OBSDA-220] In some cases, if you try to pull an image using {OTELShortName}, the image pull fails and a `Failed to pull image` error message appears. 
-There is no workaround for this issue.
 
 * link:https://issues.redhat.com/browse/TRACING-2057[TRACING-2057] The Kafka API has been updated to `v1beta2` to support the Strimzi Kafka Operator 0.23.0. However, this API version is not supported by AMQ Streams 1.6.3. If you have the following environment, your Jaeger services will not be upgraded, and you cannot create new Jaeger services or modify existing Jaeger services:
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -19,14 +19,10 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 === {JaegerName}
 
-==== Enhancements
-
 ==== Bug fixes
 
 * link:https://issues.redhat.com/browse/TRACING-3322[TRACING-3322]: Expose 16685 port on the Jaeger Query.
 * link:https://issues.redhat.com/browse/TRACING-3312[TRACING-3312]: When deploying Service Mesh on SNO in a disconnected environment , the Jaeger Pod frequently goes into Pending state.
-
-==== Known issues
 
 === {TempoName}
 
@@ -57,8 +53,6 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 * Report traces and metrics from remote clusters using OTLP/HTTP(s) in {OTELName}.
 * Collect OpenShift specific resource attributes in {OTELName} via `+resourcedetection+` processor.
 * Support managed and unmanaged state in the `+OpenTelemetryCollector+` custom resouce.
-
-==== Bug fixes
 
 ==== Known issues
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -34,7 +34,7 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 * Add Ingress and OpenShift Route configuration for the Gateway.
 * Support managed and unmanaged state in the `+TempoStack+` custom resource.
 * Expose additional protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the distributor service. When gateway is enabled only OTLP gRPC is enabled.
-* Support multitenancy without Gateway (authentication and authorization).
+* Support multitenancy without the Gateway (authentication and authorization).
 
 ==== Bug fixes
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -28,6 +28,8 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 === {TempoName}
 
+The {TempoName} is Technology Preview feature for {DTProductName}.
+
 ==== Enhancements
 
 * Support the operator level 4. This feature enables upgrade, monitoring and alerting of `+TempoStack+` instances and operator.
@@ -49,6 +51,8 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 * link:https://issues.redhat.com/browse/TRACING-3139[TRACING-3139]: When you use the Jaeger user interface (UI) with Tempo Operator, the Jaeger UI lists only services that have sent traces within the last 15 minutes. For services that have not sent traces within the last 15 minutes, those traces are still stored even though they are not visible in the Jaeger UI.
 
 === {OTELName}
+
+The {OTELName} is Technology Preview feature for {DTProductName}.
 
 ==== Enhancements
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -17,6 +17,8 @@ This release adds improvements related to the following components and concepts.
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
+Notable enhancements:
+
 * Support OTLP metrics ingestion in {OTELName}.
 * Bring {TempoName} operator to the operator level 4. This feature enables upgrade and monitoring of `+TempoStack+` instances and operator.
 * Bring {OTELName} operator to the operator level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -23,6 +23,8 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 * link:https://issues.redhat.com/browse/TRACING-3322[TRACING-3322]: Expose 16685 port on the Jaeger Query.
 * link:https://issues.redhat.com/browse/TRACING-3312[TRACING-3312]: When deploying Service Mesh on SNO in a disconnected environment , the Jaeger Pod frequently goes into Pending state.
+* link:https://issues.redhat.com/browse/TRACING-2968[29638]: Wrong port is exposed for jaeger-production-query resulting in connection refused.
+* link:https://issues.redhat.com/browse/TRACING-3173[3173]: Jaeger operator pod restarting with OOMKilled with the default memory value.
 
 === {TempoName}
 
@@ -48,11 +50,15 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 ==== Enhancements
 
-* Support OTLP metrics ingestion. The metrics can be forwarded and stored in the `+user-workload-monitoring+`.
+* Support OTLP metrics ingestion. The metrics can be forwarded and stored in the `+user-workload-monitoring+` via the Prometheus exporter.
 * Support the operator level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
 * Report traces and metrics from remote clusters using OTLP/HTTP(s) in {OTELName}.
 * Collect OpenShift specific resource attributes via `+resourcedetection+` processor.
 * Support managed and unmanaged state in the `+OpenTelemetryCollector+` custom resouce.
+
+==== Bug fixes
+
+* link:https://issues.redhat.com/browse/TRACING-3190[TRACING-3190]: OpenTelemetry operator crashlooping after receiving opentelemetry-operator.v0.74.0-5.
 
 ==== Known issues
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -29,11 +29,13 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 // link:https://issues.redhat.com/browse/TRACING-3312[TRACING-3312]
 
-* Wrong port is exposed for jaeger-production-query resulting in connection refused. Fixed by exposing Jaeger Query gRPC port (16685) on the Jaeger Query deployment.
+* Wrong port is exposed for jaeger-production-query resulting in connection refused.
+Fixed by exposing Jaeger Query gRPC port (16685) on the Jaeger Query deployment.
 
 // link:https://issues.redhat.com/browse/TRACING-2968[TRACING-29638]
 
-* Jaeger operator pod restarting with OOMKilled with the default memory value. Fixed by removing resource limits.
+* Jaeger operator pod restarting with OOMKilled with the default memory value.
+Fixed by removing resource limits.
 
 // link:https://issues.redhat.com/browse/TRACING-3173[TRACING-3173]
 
@@ -43,10 +45,12 @@ The {TempoName} is Technology Preview feature for {DTProductName}.
 
 ==== Enhancements
 
-* Support the operator level 4 (Deep Insights). This feature enables upgrade, monitoring and alerting of `+TempoStack+` instances and operator.
+* Support the operator level 4 (Deep Insights).
+This feature enables upgrade, monitoring and alerting of `+TempoStack+` instances and operator.
 * Add Ingress and OpenShift Route configuration for the Gateway.
 * Support managed and unmanaged state in the `+TempoStack+` custom resource.
-* Expose additional ingestion protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the Distributor service. When the Gateway is enabled only OTLP gRPC is enabled.
+* Expose additional ingestion protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the Distributor service.
+When the Gateway is enabled only OTLP gRPC is enabled.
 * Expose Jaeger Query gRPC endpoint on the Query Frontend service.
 * Support multitenancy without the Gateway (without authentication and authorization).
 
@@ -56,7 +60,7 @@ The {TempoName} is Technology Preview feature for {DTProductName}.
 
 // link:https://issues.redhat.com/browse/TRACING-3145[TRACING-3145]
 
-*  Enable mTLS communication between Tempo components.
+* Enable mTLS communication between Tempo components.
 
 // link:https://issues.redhat.com/browse/TRACING-3091[TRACING-3091]
 
@@ -70,14 +74,15 @@ The {TempoName} is Technology Preview feature for {DTProductName}.
 
 // link:https://issues.redhat.com/browse/TRACING-3462[TRACING-3462]
 
-* When you use the Jaeger user interface (UI) with Tempo Operator, the Jaeger UI lists only services that have sent traces within the last 15 minutes. For services that have not sent traces within the last 15 minutes, those traces are still stored even though they are not visible in the Jaeger UI.
+* When you use the Jaeger user interface (UI) with Tempo Operator, the Jaeger UI lists only services that have sent traces within the last 15 minutes.
+For services that have not sent traces within the last 15 minutes, those traces are still stored even though they are not visible in the Jaeger UI.
 
 // link:https://issues.redhat.com/browse/TRACING-3139[TRACING-3139]
 
 * Tempo query frontend service should not use internal mTLS when gateway is not deployed. This issue does not affect Jaeger Query API. The workaround is to disable mTLS.
 
 .Disable mTLS
-. Open the Tempo operator config map in editor.
+. Open the Tempo operator config map for editing.
 +
 [source,console]
 ----
@@ -89,13 +94,19 @@ $ oc edit configmap tempo-operator-manager-config -n openshift-operators <1>
 +
 [source,yaml]
 ----
-TODO
+data:
+  controller_manager_config.yaml: |
+    featureGates:
+      httpEncryption: false
+      grpcEncryption: false
+      builtInCertManagement:
+        enabled: false
 ----
 . Restart Tempo operator pod
 +
 [source,console]
 ----
-$ oc 
+$ oc rollout restart deployment.apps/tempo-operator-controller -n openshift-operators
 ----
 
 // link:https://issues.redhat.com/browse/TRACING-3510[TRACING-3510]
@@ -106,8 +117,10 @@ The {OTELName} is Technology Preview feature for {DTProductName}.
 
 ==== Enhancements
 
-* Support OTLP metrics ingestion. The metrics can be forwarded and stored in the `+user-workload-monitoring+` via the Prometheus exporter.
-* Support the operator level 4 (Deep Insights). This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
+* Support OTLP metrics ingestion.
+The metrics can be forwarded and stored in the `+user-workload-monitoring+` via the Prometheus exporter.
+* Support the operator level 4 (Deep Insights).
+This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
 * Report traces and metrics from remote clusters using OTLP/HTTP(s).
 * Collect OpenShift specific resource attributes via `+resourcedetection+` processor.
 * Support managed and unmanaged state in the `+OpenTelemetryCollector+` custom resouce.
@@ -204,7 +217,8 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
-This release introduces support for ingesting OpenTelemetry protocol (OTLP) to the {JaegerName} Operator. The Operator now automatically enables the OTLP ports:
+This release introduces support for ingesting OpenTelemetry protocol (OTLP) to the {JaegerName} Operator.
+The Operator now automatically enables the OTLP ports:
 
 * Port 4317 is used for OTLP gRPC protocol.
 * Port 4318 is used for OTLP HTTP protocol.
@@ -225,19 +239,20 @@ This release also adds support for collecting Kubernetes resource attributes to 
 |0.56
 |===
 
-
 == New features and enhancements {DTProductName} 2.4
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
 This release also adds support for auto-provisioning certificates using the Red Hat Elasticsearch Operator.
 
-* Self-provisioning, which means using the {JaegerName} Operator to call the Red Hat Elasticsearch Operator during installation. Self provisioning is fully supported with this release.
+* Self-provisioning, which means using the {JaegerName} Operator to call the Red Hat Elasticsearch Operator during installation.
+Self provisioning is fully supported with this release.
 * Creating the Elasticsearch instance and certificates first and then configuring the {JaegerShortName} to use the certificate is a Technology Preview for this release.
 
 [NOTE]
 ====
-When upgrading to {DTProductName} 2.4, the Operator recreates the Elasticsearch instance, which might take five to ten minutes. Distributed tracing will be down and unavailable for that period.
+When upgrading to {DTProductName} 2.4, the Operator recreates the Elasticsearch instance, which might take five to ten minutes.
+Distributed tracing will be down and unavailable for that period.
 ====
 
 === Component versions supported in {DTProductName} version 2.4
@@ -276,7 +291,8 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
-With this release, the {JaegerName} Operator is now installed to the `openshift-distributed-tracing` namespace by default. Before this update, the default installation had been in the `openshift-operators` namespace.
+With this release, the {JaegerName} Operator is now installed to the `openshift-distributed-tracing` namespace by default.
+Before this update, the default installation had been in the `openshift-operators` namespace.
 
 === Component versions supported in {DTProductName} version 2.3.0
 
@@ -330,7 +346,8 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features and enhancements {DTProductName} 2.0.0
 
-This release marks the rebranding of Red Hat OpenShift Jaeger to {DTProductName}. This release consists of the following changes, additions, and improvements:
+This release marks the rebranding of Red Hat OpenShift Jaeger to {DTProductName}.
+This release consists of the following changes, additions, and improvements:
 
 * {DTProductName} now consists of the following two main components:
 
@@ -338,7 +355,8 @@ This release marks the rebranding of Red Hat OpenShift Jaeger to {DTProductName}
 
 ** *{OTELName}* - This component is based on the open source link:https://opentelemetry.io/[OpenTelemetry project].
 
-* Updates {JaegerName} Operator to Jaeger 1.28. Going forward, {DTProductName} will only support the `stable` Operator channel. Channels for individual releases are no longer supported.
+* Updates {JaegerName} Operator to Jaeger 1.28. Going forward, {DTProductName} will only support the `stable` Operator channel.
+Channels for individual releases are no longer supported.
 
 * Introduces a new {OTELName} Operator based on OpenTelemetry 0.33. Note that this Operator is a Technology Preview feature.
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -34,6 +34,7 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 * Add Ingress and OpenShift Route configuration for the Gateway.
 * Support managed and unmanaged state in the `+TempoStack+` custom resource.
 * Expose additional protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the distributor service. When gateway is enabled only OTLP gRPC is enabled.
+* Support multitenancy without Gateway (authentication and authorization).
 
 ==== Bug fixes
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -19,9 +19,9 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 Notable enhancements:
 
-* Support OTLP metrics ingestion in {OTELName}.
-* Bring {TempoName} operator to the operator level 4. This feature enables upgrade and monitoring of `+TempoStack+` instances and operator.
-* Bring {OTELName} operator to the operator level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
+* Support OTLP metrics ingestion in {OTELName}. The metrics can be forwarded and stored in the `+user-workload-monitoring+` deployment.
+* Bring {TempoName} operator to the level 4. This feature enables upgrade and monitoring of `+TempoStack+` instances and operator.
+* Bring {OTELName} operator to the level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
 * Report traces and metrics from remote clusters using OTLP/HTTP(s) in {OTELName}.
 * Collect OpenShift specific resource attributes in {OTELName} via `+resourcedetection+` processor.
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -19,7 +19,7 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 
 
-
+* TODO
 
 
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -21,10 +21,21 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 ==== Bug fixes
 
-* link:https://issues.redhat.com/browse/TRACING-3322[TRACING-3322]: Expose Jaeger Query gRPC port (16685) on the Jaeger Query service.
-* link:https://issues.redhat.com/browse/TRACING-3312[TRACING-3312]: When deploying Service Mesh on SNO in a disconnected environment , the Jaeger Pod frequently goes into Pending state.
-* link:https://issues.redhat.com/browse/TRACING-2968[TRACING-29638]: Wrong port is exposed for jaeger-production-query resulting in connection refused. Fixed by exposing Jaeger Query gRPC port (16685) on the Jaeger Query deployment.
-* link:https://issues.redhat.com/browse/TRACING-3173[TRACING-3173]: Jaeger operator pod restarting with OOMKilled with the default memory value. Fixed by removing resource limits.
+* Expose Jaeger Query gRPC port (16685) on the Jaeger Query service.
+
+// link:https://issues.redhat.com/browse/TRACING-3322[TRACING-3322]
+
+* When deploying Service Mesh on SNO in a disconnected environment , the Jaeger Pod frequently goes into Pending state.
+
+// link:https://issues.redhat.com/browse/TRACING-3312[TRACING-3312]
+
+* Wrong port is exposed for jaeger-production-query resulting in connection refused. Fixed by exposing Jaeger Query gRPC port (16685) on the Jaeger Query deployment.
+
+// link:https://issues.redhat.com/browse/TRACING-2968[TRACING-29638]
+
+* Jaeger operator pod restarting with OOMKilled with the default memory value. Fixed by removing resource limits.
+
+// link:https://issues.redhat.com/browse/TRACING-3173[TRACING-3173]
 
 === {TempoName}
 
@@ -41,14 +52,27 @@ The {TempoName} is Technology Preview feature for {DTProductName}.
 
 ==== Bug fixes
 
-* link:https://issues.redhat.com/browse/TRACING-3145[TRACING-3145]: Support disconnected environments.
-* link:https://issues.redhat.com/browse/TRACING-3091[TRACING-3091]: Enable mTLS communication between Tempo components.
-* link:https://issues.redhat.com/browse/TRACING-3204[TRACING-3204]: Remove resource limits for Tempo operator.
+* Support disconnected environments.
+
+// link:https://issues.redhat.com/browse/TRACING-3145[TRACING-3145]
+
+*  Enable mTLS communication between Tempo components.
+
+// link:https://issues.redhat.com/browse/TRACING-3091[TRACING-3091]
+
+* Remove resource limits for Tempo operator.
+
+// link:https://issues.redhat.com/browse/TRACING-3204[TRACING-3204]
 
 ==== Known issues
 
-* link:https://issues.redhat.com/browse/TRACING-3462[TRACING-3462]: Custom TLS CA option is not implemented.
-* link:https://issues.redhat.com/browse/TRACING-3139[TRACING-3139]: When you use the Jaeger user interface (UI) with Tempo Operator, the Jaeger UI lists only services that have sent traces within the last 15 minutes. For services that have not sent traces within the last 15 minutes, those traces are still stored even though they are not visible in the Jaeger UI.
+* Custom TLS CA option is not implemented.
+
+// link:https://issues.redhat.com/browse/TRACING-3462[TRACING-3462]
+
+* When you use the Jaeger user interface (UI) with Tempo Operator, the Jaeger UI lists only services that have sent traces within the last 15 minutes. For services that have not sent traces within the last 15 minutes, those traces are still stored even though they are not visible in the Jaeger UI.
+
+// link:https://issues.redhat.com/browse/TRACING-3139[TRACING-3139]
 
 === {OTELName}
 
@@ -64,11 +88,15 @@ The {OTELName} is Technology Preview feature for {DTProductName}.
 
 ==== Bug fixes
 
-* link:https://issues.redhat.com/browse/TRACING-3190[TRACING-3190]: OpenTelemetry operator crashlooping after receiving opentelemetry-operator.v0.74.0-5. Fixed by properly configuring autoscaler.
+* OpenTelemetry operator crashlooping after receiving opentelemetry-operator.v0.74.0-5. Fixed by properly configuring autoscaler.
+
+// link:https://issues.redhat.com/browse/TRACING-3190[TRACING-3190]
 
 ==== Known issues
 
-* link:https://issues.redhat.com/browse/TRACING-3431[TRACING-3431]: Operator level needs to be set to 4 (Deep Insights).
+* Operator level needs to be set to 4 (Deep Insights).
+
+// link:https://issues.redhat.com/browse/TRACING-3431[TRACING-3431]
 
 === Component versions supported in {DTProductName} version 2.9
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -48,10 +48,10 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 ==== Enhancements
 
-* Support OTLP metrics ingestion in {OTELName}. The metrics can be forwarded and stored in the `+user-workload-monitoring+` deployment.
+* Support OTLP metrics ingestion. The metrics can be forwarded and stored in the `+user-workload-monitoring+`.
 * Support the operator level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
 * Report traces and metrics from remote clusters using OTLP/HTTP(s) in {OTELName}.
-* Collect OpenShift specific resource attributes in {OTELName} via `+resourcedetection+` processor.
+* Collect OpenShift specific resource attributes via `+resourcedetection+` processor.
 * Support managed and unmanaged state in the `+OpenTelemetryCollector+` custom resouce.
 
 ==== Known issues

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -23,8 +23,8 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 * link:https://issues.redhat.com/browse/TRACING-3322[TRACING-3322]: Expose 16685 port on the Jaeger Query.
 * link:https://issues.redhat.com/browse/TRACING-3312[TRACING-3312]: When deploying Service Mesh on SNO in a disconnected environment , the Jaeger Pod frequently goes into Pending state.
-* link:https://issues.redhat.com/browse/TRACING-2968[29638]: Wrong port is exposed for jaeger-production-query resulting in connection refused.
-* link:https://issues.redhat.com/browse/TRACING-3173[3173]: Jaeger operator pod restarting with OOMKilled with the default memory value.
+* link:https://issues.redhat.com/browse/TRACING-2968[TRACING-29638]: Wrong port is exposed for jaeger-production-query resulting in connection refused.
+* link:https://issues.redhat.com/browse/TRACING-3173[TRACING-3173]: Jaeger operator pod restarting with OOMKilled with the default memory value.
 
 === {TempoName}
 
@@ -33,8 +33,9 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 * Support the operator level 4. This feature enables upgrade, monitoring and alerting of `+TempoStack+` instances and operator.
 * Add Ingress and OpenShift Route configuration for the Gateway.
 * Support managed and unmanaged state in the `+TempoStack+` custom resource.
-* Expose additional protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the distributor service. When gateway is enabled only OTLP gRPC is enabled.
-* Support multitenancy without the Gateway (authentication and authorization).
+* Expose additional ingestion protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the distributor service. When gateway is enabled only OTLP gRPC is enabled.
+* Expose Jaeger Query gRPC endpoint on the Query Frontend service.
+* Support multitenancy without the Gateway (without authentication and authorization).
 
 ==== Bug fixes
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -17,25 +17,11 @@ This release adds improvements related to the following components and concepts.
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
-
-
-* TODO
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+* Support OTLP metrics ingestion in {OTELName}.
+* Bring {TempoName} operator to the operator level 4. This feature enables upgrade and monitoring of `+TempoStack+` instances and operator.
+* Bring {OTELName} operator to the operator level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
+* Report traces and metrics from remote clusters using OTLP/HTTP(s) in {OTELName}.
+* Collect OpenShift specific resource attributes in {OTELName} via `+resourcedetection+` processor.
 
 === Component versions supported in {DTProductName} version 2.9
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -21,10 +21,10 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 ==== Bug fixes
 
-* link:https://issues.redhat.com/browse/TRACING-3322[TRACING-3322]: Expose 16685 port on the Jaeger Query.
+* link:https://issues.redhat.com/browse/TRACING-3322[TRACING-3322]: Expose Jaeger Query gRPC port (16685) on the Jaeger Query service.
 * link:https://issues.redhat.com/browse/TRACING-3312[TRACING-3312]: When deploying Service Mesh on SNO in a disconnected environment , the Jaeger Pod frequently goes into Pending state.
-* link:https://issues.redhat.com/browse/TRACING-2968[TRACING-29638]: Wrong port is exposed for jaeger-production-query resulting in connection refused.
-* link:https://issues.redhat.com/browse/TRACING-3173[TRACING-3173]: Jaeger operator pod restarting with OOMKilled with the default memory value.
+* link:https://issues.redhat.com/browse/TRACING-2968[TRACING-29638]: Wrong port is exposed for jaeger-production-query resulting in connection refused. Fixed by exposing Jaeger Query gRPC port (16685) on the Jaeger Query deployment.
+* link:https://issues.redhat.com/browse/TRACING-3173[TRACING-3173]: Jaeger operator pod restarting with OOMKilled with the default memory value. Fixed by removing resource limits.
 
 === {TempoName}
 
@@ -32,10 +32,10 @@ The {TempoName} is Technology Preview feature for {DTProductName}.
 
 ==== Enhancements
 
-* Support the operator level 4. This feature enables upgrade, monitoring and alerting of `+TempoStack+` instances and operator.
+* Support the operator level 4 (Deep Insights). This feature enables upgrade, monitoring and alerting of `+TempoStack+` instances and operator.
 * Add Ingress and OpenShift Route configuration for the Gateway.
 * Support managed and unmanaged state in the `+TempoStack+` custom resource.
-* Expose additional ingestion protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the distributor service. When gateway is enabled only OTLP gRPC is enabled.
+* Expose additional ingestion protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the Distributor service. When the Gateway is enabled only OTLP gRPC is enabled.
 * Expose Jaeger Query gRPC endpoint on the Query Frontend service.
 * Support multitenancy without the Gateway (without authentication and authorization).
 
@@ -57,18 +57,18 @@ The {OTELName} is Technology Preview feature for {DTProductName}.
 ==== Enhancements
 
 * Support OTLP metrics ingestion. The metrics can be forwarded and stored in the `+user-workload-monitoring+` via the Prometheus exporter.
-* Support the operator level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
-* Report traces and metrics from remote clusters using OTLP/HTTP(s) in {OTELName}.
+* Support the operator level 4 (Deep Insights). This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
+* Report traces and metrics from remote clusters using OTLP/HTTP(s).
 * Collect OpenShift specific resource attributes via `+resourcedetection+` processor.
 * Support managed and unmanaged state in the `+OpenTelemetryCollector+` custom resouce.
 
 ==== Bug fixes
 
-* link:https://issues.redhat.com/browse/TRACING-3190[TRACING-3190]: OpenTelemetry operator crashlooping after receiving opentelemetry-operator.v0.74.0-5.
+* link:https://issues.redhat.com/browse/TRACING-3190[TRACING-3190]: OpenTelemetry operator crashlooping after receiving opentelemetry-operator.v0.74.0-5. Fixed by properly configuring autoscaler.
 
 ==== Known issues
 
-* link:https://issues.redhat.com/browse/TRACING-3431[TRACING-3431]: Operator level needs to be set to 4.
+* link:https://issues.redhat.com/browse/TRACING-3431[TRACING-3431]: Operator level needs to be set to 4 (Deep Insights).
 
 === Component versions supported in {DTProductName} version 2.9
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -17,13 +17,52 @@ This release adds improvements related to the following components and concepts.
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
-Notable enhancements:
+=== {JaegerName}
+
+==== Enhancements
+
+==== Bug fixes
+
+* link:https://issues.redhat.com/browse/TRACING-3322[TRACING-3322]: Expose 16685 port on the Jaeger Query.
+* link:https://issues.redhat.com/browse/TRACING-3312[TRACING-3312]: When deploying Service Mesh on SNO in a disconnected environment , the Jaeger Pod frequently goes into Pending state.
+
+==== Known issues
+
+=== {TempoName}
+
+==== Enhancements
+
+* Support the operator level 4. This feature enables upgrade, monitoring and alerting of `+TempoStack+` instances and operator.
+* Add Ingress and OpenShift Route configuration for the Gateway.
+* Support managed and unmanaged state in the `+TempoStack+` custom resource.
+* Expose additional protocols (Jaeger Thrift binary, Jaeger Thrift compact, Jaeger gRPC and Zipkin) in the distributor service. When gateway is enabled only OTLP gRPC is enabled.
+
+==== Bug fixes
+
+* link:https://issues.redhat.com/browse/TRACING-3145[TRACING-3145]: Support disconnected environments.
+* link:https://issues.redhat.com/browse/TRACING-3091[TRACING-3091]: Enable mTLS communication between Tempo components.
+* link:https://issues.redhat.com/browse/TRACING-3204[TRACING-3204]: Remove resource limits for Tempo operator.
+
+==== Known issues
+
+* link:https://issues.redhat.com/browse/TRACING-3462[TRACING-3462]: Custom TLS CA option is not implemented.
+* link:https://issues.redhat.com/browse/TRACING-3139[TRACING-3139]: When you use the Jaeger user interface (UI) with Tempo Operator, the Jaeger UI lists only services that have sent traces within the last 15 minutes. For services that have not sent traces within the last 15 minutes, those traces are still stored even though they are not visible in the Jaeger UI.
+
+=== {OTELName}
+
+==== Enhancements
 
 * Support OTLP metrics ingestion in {OTELName}. The metrics can be forwarded and stored in the `+user-workload-monitoring+` deployment.
-* Bring {TempoName} operator to the level 4. This feature enables upgrade and monitoring of `+TempoStack+` instances and operator.
-* Bring {OTELName} operator to the level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
+* Support the operator level 4. This feature enables upgrade and monitoring of `+OpenTelemetryCollector+` instances and operator.
 * Report traces and metrics from remote clusters using OTLP/HTTP(s) in {OTELName}.
 * Collect OpenShift specific resource attributes in {OTELName} via `+resourcedetection+` processor.
+* Support managed and unmanaged state in the `+OpenTelemetryCollector+` custom resouce.
+
+==== Bug fixes
+
+==== Known issues
+
+* link:https://issues.redhat.com/browse/TRACING-3431[TRACING-3431]: Operator level needs to be set to 4.
 
 === Component versions supported in {DTProductName} version 2.9
 

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -66,13 +66,39 @@ The {TempoName} is Technology Preview feature for {DTProductName}.
 
 ==== Known issues
 
-* Custom TLS CA option is not implemented.
+* Custom TLS CA option is not implemented for connecting to an object storage.
 
 // link:https://issues.redhat.com/browse/TRACING-3462[TRACING-3462]
 
 * When you use the Jaeger user interface (UI) with Tempo Operator, the Jaeger UI lists only services that have sent traces within the last 15 minutes. For services that have not sent traces within the last 15 minutes, those traces are still stored even though they are not visible in the Jaeger UI.
 
 // link:https://issues.redhat.com/browse/TRACING-3139[TRACING-3139]
+
+* Tempo query frontend service should not use internal mTLS when gateway is not deployed. This issue does not affect Jaeger Query API. The workaround is to disable mTLS.
+
+.Disable mTLS
+. Open the Tempo operator config map in editor.
++
+[source,console]
+----
+$ oc edit configmap tempo-operator-manager-config -n openshift-operators <1>
+----
+<1> The namespace where the Tempo operator is installed.
+
+. Disable the mTLS in the operator config.
++
+[source,yaml]
+----
+TODO
+----
+. Restart Tempo operator pod
++
+[source,console]
+----
+$ oc 
+----
+
+// link:https://issues.redhat.com/browse/TRACING-3510[TRACING-3510]
 
 === {OTELName}
 


### PR DESCRIPTION
The preview is available at https://github.com/openshift/openshift-docs/pull/63263


Useful links:
* https://issues.redhat.com/secure/ReleaseNote.jspa?version=12407470&styleName=Html&projectId=12320921&Create=Create&atl_token=AQZJ-FV3A-N91S-UDEU_0107f4bcc06243839df494816b881b5f52a471f2_lin 
* https://issues.redhat.com/browse/TRACING-3337



Upstream changelog:
* OTEL: https://github.com/open-telemetry/opentelemetry-collector/releases 
* OTEL: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases
* OTEL: https://github.com/open-telemetry/opentelemetry-operator
* Jaeger: https://github.com/jaegertracing/jaeger/releases
* Jaeger: https://github.com/jaegertracing/jaeger-operator/blob/main/CHANGELOG.md
* Tempo: https://github.com/grafana/tempo/releases
* Tempo: https://github.com/grafana/tempo-operator/releases