### PR TITLE
TRACING-3264: distr-otel: add description for OpenCensus Receiver

### DIFF
--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -244,15 +244,14 @@ The Zipkin receiver ingests data in the Zipkin v1 and v2 formats.
 <2> The TLS server side configuration. See the OTLP receiver configuration section for more details.
 
 [id="opencensus-receiver_{context}"]
-==== OpenCensus Receiver
+==== OpenCensus receiver
 
-The OpenCensus Receiver provides backwards compatibility with the OpenCensus project in order
-to ease migration of instrumented codebases. It receives data via gRPC or HTTP/Json using OpenCensus format.
+The OpenCensus receiver provides backwards compatibility with the OpenCensus project for easier migration of instrumented codebases. It receives data in the OpenCensus format via gRPC or HTTP and Json.
 
 * Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
 * Supported signals: metrics, traces
 
-.OpenTelemetry Collector custom resource with enabled OpenCensus receiver
+.OpenTelemetry Collector custom resource with the enabled OpenCensus receiver
 [source,yaml]
 ----
   config: |
@@ -261,8 +260,7 @@ to ease migration of instrumented codebases. It receives data via gRPC or HTTP/J
         endpoint: 0.0.0.0:9411 <1>
         tls: <2>
         cors_allowed_origins: <3>
-          # Origins can have wildcards with *, use * by itself to match any origin.
-          - https://*.example.com
+          - https://*.<example>.com
 
     service:
       pipelines:
@@ -270,9 +268,9 @@ to ease migration of instrumented codebases. It receives data via gRPC or HTTP/J
           receivers: [opencensus]
           ...
 ----
-<1> The OpenCensus endpoint. If omitted, the default `+0.0.0.0:55678+` is used.
-<2> The TLS server side configuration. See the OTLP receiver configuration section for more details.
-<3> The HTTP/Json endpoint can also optionally configure CORS, which is enabled by specifying a list of allowed CORS origins in this field.
+<1> The OpenCensus endpoint. If omitted, the default is `+0.0.0.0:55678+`.
+<2> The TLS server-side configuration. See the OTLP receiver configuration section for more details.
+<3> You can also use the HTTP JSON endpoint to optionally configure CORS, which is enabled by specifying a list of allowed CORS origins in this field. Wildcards with `*` are accepted under `cors_allowed_origins`. To match any origin, enter only `*`.
 
 [id="processors_{context}"]
 === Processors

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -243,6 +243,37 @@ The Zipkin receiver ingests data in the Zipkin v1 and v2 formats.
 <1> The Zipkin HTTP endpoint. If omitted, the default `+0.0.0.0:9411+` is used.
 <2> The TLS server side configuration. See the OTLP receiver configuration section for more details.
 
+[id="opencensus-receiver_{context}"]
+==== OpenCensus Receiver
+
+The OpenCensus Receiver provides backwards compatibility with the OpenCensus project in order
+to ease migration of instrumented codebases. It receives data via gRPC or HTTP/Json using OpenCensus format.
+
+* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
+* Supported signals: metrics, traces
+
+.OpenTelemetry Collector custom resource with enabled OpenCensus receiver
+[source,yaml]
+----
+  config: |
+    receivers:
+      opencensus:
+        endpoint: 0.0.0.0:9411 <1>
+        tls: <2>
+        cors_allowed_origins: <3>
+          # Origins can have wildcards with *, use * by itself to match any origin.
+          - https://*.example.com
+
+    service:
+      pipelines:
+        traces:
+          receivers: [opencensus]
+          ...
+----
+<1> The OpenCensus endpoint. If omitted, the default `+0.0.0.0:55678+` is used.
+<2> The TLS server side configuration. See the OTLP receiver configuration section for more details.
+<3> The HTTP/Json endpoint can also optionally configure CORS, which is enabled by specifying a list of allowed CORS origins in this field.
+
 [id="processors_{context}"]
 === Processors
 
@@ -624,31 +655,6 @@ The OTLP HTTP exporter exports data using the OpenTelemetry protocol (OTLP).
 <1> The OTLP HTTP endpoint. If the `+https://+` scheme is used, then client transport security is enabled and overrides the `insecure` setting in the `tls`.
 <2> The client side TLS configuration. Defines paths to TLS certificates.
 <3> Headers are sent in every HTTP request.
-
-[id="jaeger-exporter_{context}"]
-==== Jaeger exporter
-
-The Jaeger exporter exports data using the Jaeger proto format through gRPC.
-
-* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
-* Supported signals: traces
-
-.OpenTelemetry Collector custom resource with enabled Jaeger exporter
-[source,yaml]
-----
-  config: |
-    exporters:
-      jaeger:
-        endpoint: jaeger-all-in-one:14250 <1>
-        tls: <2>
-    service:
-      pipelines:
-        traces:
-          exporters: [jaeger]
-----
-<1> The Jaeger gRPC endpoint.
-<2> The client side TLS configuration. Defines paths to TLS certificates.
-
 
 [id="logging-exporter_{context}"]
 ==== Logging exporter


### PR DESCRIPTION
There was some Git complication that destroyed the diffs for a few PRs, including this one.
I've rebased this branch and am opening this PR to merge the changes from Bene's PR: https://github.com/max-cx/openshift-docs/pull/15.

Branch: https://github.com/max-cx/openshift-docs/tree/distributed-tracing-3.0_opencensus
  Changes to be committed:
	modified:   modules/distr-tracing-otel-config-collector.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/TRACING-3264

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
