### PR TITLE
deprecate jaeger exporter and document otlp

### DIFF
--- a/modules/distr-tracing-config-jaeger-collector.adoc
+++ b/modules/distr-tracing-config-jaeger-collector.adoc
@@ -63,4 +63,46 @@ The Collectors are stateless and thus many instances of Jaeger Collector can be 
   log-level:
 |Logging level for the Collector.
 |Possible values: `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
+
+|options:
+  otlp:
+    enabled: true
+    grpc:
+      host-port: 4317
+      max-connection-age: 0s
+      max-connection-age-grace: 0s
+      max-message-size: 4194304
+      tls:
+        enabled: false
+        cert: /path/to/cert.crt
+        cipher-suites: "TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256"
+        client-ca: /path/to/cert.ca
+        reload-interval: 0s
+        min-version: 1.2
+        max-version: 1.3
+|To accept OTLP/gRPC we must enable otlp explicit. All other options are optional.
+
+|options:
+  otlp:
+    enabled: true
+    http:
+      cors:
+        allowed-headers: [<header-name>[, <header-name>]*]
+        allowed-origins: *
+      host-port: 4318
+      max-connection-age: 0s
+      max-connection-age-grace: 0s
+      max-message-size: 4194304
+      read-timeout: 0s
+      read-header-timeout: 2s
+      idle-timeout: 0s
+      tls:
+        enabled: false
+        cert: /path/to/cert.crt
+        cipher-suites: "TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256"
+        client-ca: /path/to/cert.ca
+        reload-interval: 0s
+        min-version: 1.2
+        max-version: 1.3
+|To accept OTLP/HTTP we must enable otlp explicit. All other options are optional.
 |===

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -625,32 +625,6 @@ The OTLP HTTP exporter exports data using the OpenTelemetry protocol (OTLP).
 <2> The client side TLS configuration. Defines paths to TLS certificates.
 <3> Headers are sent in every HTTP request.
 
-[id="jaeger-exporter_{context}"]
-==== Jaeger exporter
-
-The Jaeger exporter exports data using the Jaeger proto format through gRPC.
-
-* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
-* Supported signals: traces
-
-.OpenTelemetry Collector custom resource with enabled Jaeger exporter
-[source,yaml]
-----
-  config: |
-    exporters:
-      jaeger:
-        endpoint: jaeger-all-in-one:14250 <1>
-        tls: <2>
-    service:
-      pipelines:
-        traces:
-          exporters: [jaeger]
-----
-<1> The Jaeger gRPC endpoint.
-<2> The client side TLS configuration. Defines paths to TLS certificates.
-
-
-[id="logging-exporter_{context}"]
 ==== Logging exporter
 
 The Logging exporter prints data to the standard output.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
